### PR TITLE
overwrite existing themes when importing theme with the same name

### DIFF
--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/ColorThemeManager.java
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/ColorThemeManager.java
@@ -108,6 +108,17 @@ public class ColorThemeManager {
         }
     }
 
+    public void clearImportedThemes() {
+        IPreferenceStore store = getPreferenceStore();
+        int i = 1;
+        while (store.contains("importedColorThemeName" + i)
+                || store.contains("importedColorTheme" + i)) {
+            store.setToDefault("importedColorThemeName" + i);
+            store.setToDefault("importedColorTheme" + i);
+            i++;
+        }
+    }
+    
     private static IPreferenceStore getPreferenceStore() {
         return Activator.getDefault().getPreferenceStore();
     }

--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/ColorThemePreferencePage.java
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/ColorThemePreferencePage.java
@@ -52,10 +52,14 @@ public class ColorThemePreferencePage extends FieldEditorPreferencePage
         for (String theme : themeNames)
 	        choices[i++] = new String[] {theme, theme};
 
-	    colorThemeEditor = new RadioGroupFieldEditor("colorTheme",
-		                                             "Current color theme:", 1,
-		                                             choices,
-		                                             getFieldEditorParent());
+        colorThemeEditor = new RadioGroupFieldEditor("colorTheme",
+                "Current color theme:", 1, choices, getFieldEditorParent()) {
+            @Override
+            protected void doLoadDefault() {
+                colorThemeManager.clearImportedThemes();
+                super.doLoadDefault();
+            }
+        };
 	    addField(colorThemeEditor);
 	}
 


### PR DESCRIPTION
I made some changes to "'ColorThemeManager.saveTheme".

When an existing theme is saved again, the theme gets overwitten.
Stock themes can be "overwritten" too. 
(You can get the default stock theme back by removing the imported theme from the preference file)
