### PR TITLE
Added CDT Makefile editor mappings

### DIFF
--- a/com.github.eclipsecolortheme/mappings/org.eclipse.cdt.make.ui.xml
+++ b/com.github.eclipsecolortheme/mappings/org.eclipse.cdt.make.ui.xml
@@ -1,0 +1,10 @@
+<eclipseColorThemeMapping plugin="org.eclipse.cdt.make.ui" created="2012-05-07 15:25:08">
+  <mappings>
+    <mapping pluginKey="org.eclipse.cdt.make.ui.editor.comment" themeKey="multiLineComment"/>
+    <mapping pluginKey="org.eclipse.cdt.make.ui.editor.default" themeKey="foreground"/>
+    <mapping pluginKey="org.eclipse.cdt.make.ui.editor.function" themeKey="method"/>
+    <mapping pluginKey="org.eclipse.cdt.make.ui.editor.keyword" themeKey="keyword"/>
+    <mapping pluginKey="org.eclipse.cdt.make.ui.editor.macro_def" themeKey="methodDeclaration"/>
+    <mapping pluginKey="org.eclipse.cdt.make.ui.editor.macro_ref" themeKey="methodDeclaration"/>
+  </mappings>
+</eclipseColorThemeMapping>

--- a/com.github.eclipsecolortheme/plugin.xml
+++ b/com.github.eclipsecolortheme/plugin.xml
@@ -23,6 +23,12 @@
          point="com.github.eclipsecolortheme.mapper">
       <mapper
             class="com.github.eclipsecolortheme.mapper.GenericMapper"
+            name="Make"
+            pluginId="org.eclipse.cdt.make.ui"
+            xml="mappings/org.eclipse.cdt.make.ui.xml">
+      </mapper>
+      <mapper
+            class="com.github.eclipsecolortheme.mapper.GenericMapper"
             name="Ant"
             pluginId="org.eclipse.ant.ui"
             xml="mappings/org.eclipse.ant.ui.xml">
@@ -135,7 +141,7 @@
             pluginId="com.adobe.flexide.css.core"
             xml="mappings/com.adobe.flexide.css.core.xml">
       </mapper>
-   
+
    <mapper
          class="com.github.eclipsecolortheme.mapper.GenericMapper"
          name="Scala"


### PR DESCRIPTION
I have added mappings for the CDT Makefile editor. I have tested it on my machine, and it works.

I use Linux Fedora 16 and Eclipse 3.7.2 Indigo (64 bits).
