### PR TITLE
Fix IndexOutOfBoundsException for case when nothing was selected

### DIFF
--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/ColorThemePreferencePage.java
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/ColorThemePreferencePage.java
@@ -204,7 +204,7 @@ public class ColorThemePreferencePage extends PreferencePage
 	                new IEditorReference[editorsToClose.size()]), true);
 	        }
 	        
-	        if ( themeSelectionList.getSelectionCount() > 0 ) {
+	        if (themeSelectionList.getSelectionCount() > 0) {
 	            String selectedThemeName = themeSelectionList.getSelection()[0];
 	            getPreferenceStore().setValue("colorTheme", selectedThemeName);
 	            colorThemeManager.applyTheme(selectedThemeName);


### PR DESCRIPTION
I've seen an IndexOutOfBounds exception on occasion while using this plugin. The stacktrace points to the line containing: String selectedThemeName = themeSelectionList.getSelection()[0];

It is possible to reach this line without having made a selection, causing the array to be empty. The fix is pretty simple: check that the array contains at least one element and then only act on it if that element is present.
