### PR TITLE
Fix XML parsing so that all valid encodings are supported

### DIFF
--- a/com.github.eclipsecolortheme.test/src/com/github/eclipsecolortheme/test/ColorThemeTest.java
+++ b/com.github.eclipsecolortheme.test/src/com/github/eclipsecolortheme/test/ColorThemeTest.java
@@ -19,7 +19,7 @@ public class ColorThemeTest {
 	
 	@Before
 	public void setUp() {
-		colorTheme = new ColorTheme();
+		colorTheme = new ColorTheme("<colorTheme></colorTheme>");
 	}
 	
 	@Test
@@ -30,7 +30,7 @@ public class ColorThemeTest {
 		assertThat(colorTheme.getWebsite(), nullValue());
 		assertThat(colorTheme.getEntries(), nullValue());
 	}
-	
+
 	@Test
 	public void id() {
 		colorTheme.setId("id");
@@ -54,7 +54,12 @@ public class ColorThemeTest {
 		colorTheme.setWebsite("website");
 		assertThat(colorTheme.getWebsite(), is("website"));
 	}
-	
+
+	@Test
+	public void source() {
+		assertThat(colorTheme.getSource(), is("<colorTheme></colorTheme>"));
+	}
+
 	@Test
 	public void entries() {
 		Map<String, ColorThemeSetting> entries = new HashMap<String, ColorThemeSetting>();

--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/ColorTheme.java
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/ColorTheme.java
@@ -8,12 +8,21 @@ public class ColorTheme {
     private String name;
     private String author;
     private String website;
+    private String source;
     private Map<String, ColorThemeSetting> entries;
+
+    public ColorTheme(String source) {
+        this.source = source;
+    }
+
+    public String getSource() {
+        return source;
+    }
 
     public String getId() {
     	return id;
     }
-    
+
     public void setId(String id) {
     	this.id = id;
     }


### PR DESCRIPTION
Currently only ASCII encoding was supported even if `<?xml version="1.0" encoding="utf-8"?>` was specified, because encoding was taken as system's default ignoring this.

This PR fixes it so all encodings are supported and this header is correctly parsed.

[I created my theme](http://eclipsecolorthemes.org/?view=theme&id=19553) but because author is `Dāvis` it didn't imported it with error `This is not a valid theme file.`

Theme name can also contain any Unicode characters and works good in Eclipse
