### PR TITLE
Support for Haskell Editor from EclipseFP

### DIFF
--- a/com.github.eclipsecolortheme/mappings/net.sf.eclipsefp.haskell.ui.xml
+++ b/com.github.eclipsecolortheme/mappings/net.sf.eclipsefp.haskell.ui.xml
@@ -1,0 +1,23 @@
+<eclipseColorThemeMapping plugin="net.sf.eclipsefp.haskell.ui"
+	created="2013-09-13 00:00:00">
+	<mappings>
+		<mapping pluginKey="commentColor" themeKey="singleLineComment" />
+		<mapping pluginKey="pragmaColor" themeKey="multiLineComment" />
+		<mapping pluginKey="literateCommentColor" themeKey="multiLineComment" />
+		<mapping pluginKey="sourceHoverBackgroundColor" themeKey="sourceHoverBackground" />
+		<mapping pluginKey="stringColor" themeKey="string" />
+		<mapping pluginKey="charColor" themeKey="string" />
+		<mapping pluginKey="symbolColor" themeKey="bracket" />
+		<mapping pluginKey="varSymColor" themeKey="operator" />
+		<mapping pluginKey="keywordColor" themeKey="keyword" />
+		<mapping pluginKey="functionColor" themeKey="foreground" />
+		<mapping pluginKey="varColor" themeKey="foreground" />
+		<mapping pluginKey="conColor" themeKey="class" />
+		<mapping pluginKey="cppColor" themeKey="annotation" />
+		<mapping pluginKey="thColor" themeKey="annotation" />
+		<mapping pluginKey="docColor" themeKey="javadoc" />
+	</mappings>
+	<semanticHighlightingMappings>
+
+	</semanticHighlightingMappings>
+</eclipseColorThemeMapping>

--- a/com.github.eclipsecolortheme/plugin.xml
+++ b/com.github.eclipsecolortheme/plugin.xml
@@ -293,6 +293,12 @@
          pluginId="org.eclipse.xtend.core.Xtend"
          xml="mappings/org.eclipse.xtend.ide.xml">
    </mapper>
+   <mapper
+         class="com.github.eclipsecolortheme.mapper.GenericMapper"
+         name="Haskell"
+         pluginId="net.sf.eclipsefp.haskell.ui"
+         xml="mappings/net.sf.eclipsefp.haskell.ui.xml">
+   </mapper>
    </extension>
    <extension
          point="com.github.eclipsecolortheme.theme">


### PR DESCRIPTION
This pull request is to enable the color themes to work with the Haskell editor provided by the EclipseFP plugins. (http://eclipsefp.github.io/)
