### PR TITLE
Scala-ide uses colour instead of color for their property names.

### DIFF
--- a/com.github.eclipsecolortheme/mappings/org.scala-ide.sdt.core.xml
+++ b/com.github.eclipsecolortheme/mappings/org.scala-ide.sdt.core.xml
@@ -1,10 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <eclipseColorThemeMapping plugin="org.scala-ide.sdt.core" created="2011-03-30 18:31:19">
   <mappings>
+    <mapping pluginKey="syntaxColouring.singleLineComment.colour"         themeKey="singleLineComment" />
+    <mapping pluginKey="syntaxColouring.multiLineComment.colour"          themeKey="multiLineComment" />
+    <mapping pluginKey="syntaxColouring.scaladoc.colour"                  themeKey="javadoc" />
+    <mapping pluginKey="syntaxColouring.scaladocAnnotation.colour"        themeKey="javadocKeyword" />
+    <mapping pluginKey="syntaxColouring.operator.colour"                  themeKey="operator" />
+    <mapping pluginKey="syntaxColouring.keyword.colour"                   themeKey="keyword" />
+    <mapping pluginKey="syntaxColouring.return.colour"                    themeKey="keyword" />
+    <mapping pluginKey="syntaxColouring.string.colour"                    themeKey="string" />
+    <mapping pluginKey="syntaxColouring.multiLineString.colour"           themeKey="string" />
+    <mapping pluginKey="syntaxColouring.bracket.colour"                   themeKey="bracket" />
+    <mapping pluginKey="syntaxColouring.numberLiteral.colour"             themeKey="number" />
+    <mapping pluginKey="syntaxColouring.default.colour"                   themeKey="foreground" />
+
+    <mapping pluginKey="syntaxColouring.xml.comment.colour"               themeKey="multiLineComment" />
+    <mapping pluginKey="syntaxColouring.xml.attributeValue.colour"        themeKey="string" />
+    <mapping pluginKey="syntaxColouring.xml.attributeName.colour"         themeKey="keyword" />
+    <mapping pluginKey="syntaxColouring.xml.equals.colour"                themeKey="foreground" />
+    <mapping pluginKey="syntaxColouring.xml.tagDelimiter.colour"          themeKey="foreground" />
+    <mapping pluginKey="syntaxColouring.xml.tagName.colour"               themeKey="foreground" />
+    <mapping pluginKey="syntaxColouring.xml.processingInstruction.colour" themeKey="foreground" />
+    <mapping pluginKey="syntaxColouring.xml.cdata.colour"                 themeKey="singleLineComment" />
+
+    <mapping pluginKey="syntaxColouring.semantic.annotation.colour"       themeKey="annotation" />
+    <mapping pluginKey="syntaxColouring.semantic.caseClass.colour"        themeKey="class" />
+    <mapping pluginKey="syntaxColouring.semantic.caseObject.colour"       themeKey="enum" />
+    <mapping pluginKey="syntaxColouring.semantic.class.colour"            themeKey="class" />
+    <mapping pluginKey="syntaxColouring.semantic.lazyLocalVal.colour"     themeKey="enum" />
+    <mapping pluginKey="syntaxColouring.semantic.lazyTemplateVal.colour"  themeKey="abstractMethod" />
+    <mapping pluginKey="syntaxColouring.semantic.localVal.colour"         themeKey="staticFinalField" />
+    <mapping pluginKey="syntaxColouring.semantic.localVar.colour"         themeKey="localVariable" />
+    <mapping pluginKey="syntaxColouring.semantic.method.colour"           themeKey="methodDeclaration" />
+    <mapping pluginKey="syntaxColouring.semantic.object.colour"           themeKey="enum" />
+    <mapping pluginKey="syntaxColouring.semantic.package.colour"          themeKey="enum" />
+    <mapping pluginKey="syntaxColouring.semantic.methodParam.colour"      themeKey="parameterVariable" />
+    <mapping pluginKey="syntaxColouring.semantic.templateVal.colour"      themeKey="abstractMethod" />
+    <mapping pluginKey="syntaxColouring.semantic.templateVar.colour"      themeKey="localVariableDeclaration" />
+    <mapping pluginKey="syntaxColouring.semantic.trait.colour"            themeKey="interface" />
+    <mapping pluginKey="syntaxColouring.semantic.type.colour"             themeKey="typeArgument" />
+    <mapping pluginKey="syntaxColouring.semantic.typeParameter.colour"    themeKey="typeParameter" />
+
+    <!-- Support the proper Eclipse naming in the case the scala-sbt moves in that direction -->
     <mapping pluginKey="syntaxColoring.singleLineComment.color"         themeKey="singleLineComment" />
     <mapping pluginKey="syntaxColoring.multiLineComment.color"          themeKey="multiLineComment" />
     <mapping pluginKey="syntaxColoring.scaladoc.color"                  themeKey="javadoc" />
-    <mapping pluginKey="syntaxColoring.scaladocAnnotation"              themeKey="javadocKeyword" />
+    <mapping pluginKey="syntaxColoring.scaladocAnnotation.color"        themeKey="javadocKeyword" />
     <mapping pluginKey="syntaxColoring.operator.color"                  themeKey="operator" />
     <mapping pluginKey="syntaxColoring.keyword.color"                   themeKey="keyword" />
     <mapping pluginKey="syntaxColoring.return.color"                    themeKey="keyword" />


### PR DESCRIPTION
Let's support both until one of the two changes. 

@soc created a [pull request](https://github.com/scala-ide/scala-ide/pull/476) for the @scala-ide team to rename their option keys to "color" instead of "colour" but it was closed until he does a little more work on it. 

In the meantime, eclipse-color-theme will not work with scala as it is looking for keys that don't exist in the scala-ide.

This pull request supports both sets of key names so scala devs can benefit from eclipse-color-themes.
