### PR TITLE
(erlide support) remap the `default' element to `bracket'

### DIFF
--- a/com.github.eclipsecolortheme/mappings/org.erlide.ui.xml
+++ b/com.github.eclipsecolortheme/mappings/org.erlide.ui.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <eclipseColorThemeMapping plugin="org.erlide.ui" created="2011-08-05 13:20:00">
     <mappings>
-        <mapping pluginKey="editor/colors/default" themeKey="foreground"/>
+        <mapping pluginKey="editor/colors/default" themeKey="bracket"/>
         <mapping pluginKey="editor/colors/keyword" themeKey="keyword"/>
         <mapping pluginKey="editor/colors/integer" themeKey="number"/>
         <mapping pluginKey="editor/colors/float" themeKey="number"/>


### PR DESCRIPTION
In fact, in ErlIDE, the `default` element will highlight just all the brackets and other operators like `:`, `/` etc. 
So, re-map it to `bracket` so that we can have more customizations.
