### PR TITLE
Explicitly import hamcrest core bundle for tests.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 1.1.0
 =====
+* Explicitly import hamcrest core bundle for tests.
 
 1.0.0 (2014-10-26)
 ==================

--- a/com.github.eclipsecolortheme.test/META-INF/MANIFEST.MF
+++ b/com.github.eclipsecolortheme.test/META-INF/MANIFEST.MF
@@ -7,4 +7,5 @@ Bundle-Vendor: GitHub
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: com.github.eclipsecolortheme;bundle-version="0.9.0",
  org.junit,
+ org.hamcrest.core,
  org.eclipse.core.runtime;bundle-version="3.6.0"


### PR DESCRIPTION
Background:

As a linux distro integrator it is a hard rule that we must build everything from source, which includes the restrictions on re-using pre-built binary artefacts from Orbit. Because we can't re-use things from Orbit, it means that osgi metadata sometimes differs between the upstream project's builds and Orbit builds of a given third-party dependency. We try to stay as close as possible to the upstream project's build to reduce our patch maintenance burden.

The problem:

The com.github.eclipsecolortheme.test bundle makes direct use of the hamcrest core API but in the manifest, it does not import "org.hamcrest.core". This means that when re-building against versions of junit that do not reexport the hamcrest core API, the build will fail. Adding an extra requirement on the "org.hamcrest.core" bundle will prevent such a failure.

This pull request contains a small (one-line) patch that makes the dependency on hamcrest more explicit.