### PR TITLE
Use latest tycho, allow building against kepler, luna, mars

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ You can generate an update site using [Maven](http://maven.apache.org/):
 This will create an update site in
 _com.github.eclipsecolortheme.updatesite/target/repository_.
 
+By default, Eclipse Color Theme will be built against the Eclipse Mars
+version of the platform. You can build against either Eclipse Luna or
+Kepler by setting the "platform-version" property, for example:
+
+    mvn clean verify -Dplatform-version=kepler
+
 License
 -------
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,14 @@
 	</modules>
 
 	<properties>
-		<tycho-version>0.18.1</tycho-version>
+		<tycho-version>0.23.0</tycho-version>
 	</properties>
 
 	<repositories>
 		<repository>
-			<id>kepler</id>
+			<id>eclipse-platform</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/kepler</url>
+			<url>${eclipse.repo.url}</url>
 		</repository>
 	</repositories>
 
@@ -129,4 +129,43 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>platform-mars</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+				<property>
+					<name>platform-version</name>
+					<value>mars</value>
+				</property>
+			</activation>
+			<properties>
+				<eclipse.repo.url>http://download.eclipse.org/releases/mars</eclipse.repo.url>
+			</properties>
+		</profile>
+		<profile>
+			<id>platform-luna</id>
+			<activation>
+				<property>
+					<name>platform-version</name>
+					<value>luna</value>
+				</property>
+			</activation>
+			<properties>
+				<eclipse.repo.url>http://download.eclipse.org/releases/luna</eclipse.repo.url>
+			</properties>
+		</profile>
+		<profile>
+			<id>platform-kepler</id>
+			<activation>
+				<property>
+					<name>platform-version</name>
+					<value>kepler</value>
+				</property>
+			</activation>
+			<properties>
+				<eclipse.repo.url>http://download.eclipse.org/releases/kepler</eclipse.repo.url>
+			</properties>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
This change updates the build to use the latest version of tycho and allows you to build against any of the last three major Eclipse versions.

By default, it builds against Eclipse Mars. You can build against Eclipse Luna or Kepler by passing, for example: "-Dplatform-version=kepler"

This is useful for making sure eclipse-color-theme remains compatible with all the Eclipse versions that you wish to support.
