### PR TITLE
Minor release-eng updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ You can generate an update site using [Maven](http://maven.apache.org/):
 This will create an update site in
 _com.github.eclipsecolortheme.updatesite/target/repository_.
 
-By default, Eclipse Color Theme will be built against the Eclipse Mars
-version of the platform. You can build against either Eclipse Luna or
-Kepler by setting the "platform-version" property, for example:
+By default, Eclipse Color Theme will be built against the Eclipse Neon
+version of the platform. You can build against older versions of the
+platform by setting the "platform-version" property, for example:
 
-    mvn clean verify -Dplatform-version=kepler
+    mvn clean verify -Dplatform-version=mars
 
 License
 -------

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
 	<packaging>pom</packaging>
 	<version>1.1.0-SNAPSHOT</version>
 
+	<prerequisites>
+		<maven>3.1.1</maven>
+	</prerequisites>
+
 	<modules>
 		<module>com.github.eclipsecolortheme</module>
 		<module>com.github.eclipsecolortheme.feature</module>
@@ -15,7 +19,7 @@
 	</modules>
 
 	<properties>
-		<tycho-version>0.23.0</tycho-version>
+		<tycho-version>0.26.0</tycho-version>
 	</properties>
 
 	<repositories>
@@ -131,9 +135,21 @@
 
 	<profiles>
 		<profile>
-			<id>platform-mars</id>
+			<id>platform-neon</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
+				<property>
+					<name>platform-version</name>
+					<value>neon</value>
+				</property>
+			</activation>
+			<properties>
+				<eclipse.repo.url>http://download.eclipse.org/releases/neon</eclipse.repo.url>
+			</properties>
+		</profile>
+		<profile>
+			<id>platform-mars</id>
+			<activation>
 				<property>
 					<name>platform-version</name>
 					<value>mars</value>


### PR DESCRIPTION
This is a follow-up to pr #229 

Build against Neon by default (current newest version of platform)
Update to tycho 0.26 (current newest version of the tycho build tools)
