### PR TITLE
Issue 70 offline previewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Added support for the [Apache IvyDE](http://ant.apache.org/ivy/ivyde/).
 * Fixed outdated mapping for the Go editor (goclipse).
 * Explicitly import hamcrest core bundle for tests.
+* Added offline theme previewer.
 
 1.0.0 (2014-10-26)
 ==================

--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/ColorThemePreferencePage.java
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/ColorThemePreferencePage.java
@@ -4,6 +4,7 @@ import java.io.BufferedInputStream;
 import java.io.CharConversionException;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -11,6 +12,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.PreferencePage;
@@ -41,8 +43,10 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 
 import com.github.eclipsecolortheme.Activator;
+import com.github.eclipsecolortheme.Color;
 import com.github.eclipsecolortheme.ColorTheme;
 import com.github.eclipsecolortheme.ColorThemeManager;
+import com.github.eclipsecolortheme.ColorThemeSetting;
 
 /** The preference page for managing color themes. */
 public class ColorThemePreferencePage extends PreferencePage
@@ -187,16 +191,108 @@ public class ColorThemePreferencePage extends PreferencePage
                 setLinkTarget(websiteLink, website);
                 websiteLink.setVisible(true);
             }
-            String id = theme.getId();
             Browser browser = getBrowser();
-            if (browser != null)
-                browser.setUrl(
-                    "http://www.eclipsecolorthemes.org/static/themes/java/"
-                    + id + ".html");
+            if (browser != null) {
+                browser.setText(getThemeHtml(theme));
+            }
+
             themeDetails.setVisible(true);
             authorLabel.pack();
             websiteLink.pack();
         }
+    }
+
+    private String getThemeHtml(ColorTheme theme) {
+        char[] buf = new char[1024];
+        StringBuffer complete = new StringBuffer();
+        InputStreamReader isr = null;
+        try {
+            isr = new InputStreamReader(ColorThemePreferencePage.class.getResourceAsStream("preview.html"));
+            int numRead = 0;
+            while ((numRead = isr.read(buf)) > 0) {
+                complete.append(buf, 0, numRead);
+            }
+        } catch (IOException e) {
+            Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "Failed to fetch preview", e));
+            return "<html><body>Failed to create preview</body></html>";
+        } finally {
+            if (isr != null) {
+                try {
+                    isr.close();
+                } catch (IOException e) {
+                    Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.PLUGIN_ID, "Failed to close preview html", e));
+                }
+            }
+        }
+
+        String html = complete.toString();
+        String css = createThemeCss(theme);
+
+        html = html.replace("${theme_css}", css);
+
+        return html;
+    }
+
+    private String createThemeCss(ColorTheme theme) {
+        StringBuffer css = new StringBuffer();
+
+        StringBuilder defaultClass = new StringBuilder(".defaultClass {\n");    // This contains all the basic foreground and background colors
+        defaultClass.append("font-family: \"Courier New\", \"Lucida Console\", Monospace;\n");
+
+        for (Map.Entry<String, ColorThemeSetting> setting : theme.getEntries().entrySet()) {
+            ColorThemeSetting settingVal = setting.getValue();
+            Color c = settingVal.getColor();
+
+            if (setting.getKey().equals("foreground")) {
+                if (c != null) {
+                    defaultClass.append("color: " + c.asHex() + ";\n");
+                }
+            } else if (setting.getKey().equals("background")) {
+                if (c != null) {
+                    defaultClass.append("background: " + c.asHex() + ";\n");
+                }
+            } else {
+                StringBuilder cssClass = new StringBuilder();
+                cssClass.append(String.format(".%s {\n", setting.getKey()));        // The class name and beginning of class definition
+
+                if (c != null) {
+                    cssClass.append("color: " + c.asHex() + ";\n");
+                }
+
+                if (settingVal.isBoldEnabled() != null && settingVal.isBoldEnabled()) {
+                    cssClass.append("font-weight: bold;\n");
+                }
+
+                if (settingVal.isItalicEnabled() != null && settingVal.isItalicEnabled()) {
+                    cssClass.append("font-style: italic;\n");
+                }
+
+                String decoration = "";
+                if (settingVal.isStrikethroughEnabled() != null && settingVal.isStrikethroughEnabled()) {
+                    decoration = "line-through";
+                }
+
+                if (settingVal.isUnderlineEnabled() != null && settingVal.isUnderlineEnabled()) {
+                    if (decoration.length() > 0) {
+                        decoration += "|";
+                    }
+                    decoration += "underline";
+                }
+
+                if (decoration.length() > 0) {
+                    cssClass.append("text-decoration: " + decoration + ";\n");
+                }
+
+                cssClass.append("}\n"); // Close class
+
+                css.append(cssClass);
+            }
+        }
+
+        defaultClass.append("}\n");    // Close the default class
+        css.append(defaultClass);
+
+        return css.toString();
     }
 
     @Override

--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/ColorThemePreferencePage.java
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/ColorThemePreferencePage.java
@@ -238,6 +238,7 @@ public class ColorThemePreferencePage extends PreferencePage
 
         StringBuilder defaultClass = new StringBuilder(".defaultClass {\n");    // This contains all the basic foreground and background colors
         defaultClass.append("font-family: \"Courier New\", \"Lucida Console\", Monospace;\n");
+        defaultClass.append("font-size: small;\n");
 
         for (Map.Entry<String, ColorThemeSetting> setting : theme.getEntries().entrySet()) {
             ColorThemeSetting settingVal = setting.getValue();

--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/preview.html
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/preview.html
@@ -9,20 +9,17 @@ ${theme_css}
 <body class="defaultClass">
 <span class="keyword">public class</span> <span class="class">Demo</span> <span class="bracket">{</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">private static final</span> <span class="class">String</span> <span class="staticFinalField">CONSTANT</span> = <span class="string">"String"</span>;<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">private</span> <span class="class">Object</span> o;	<span class="singleLineComment">// TODO needs better name</span><br/> 
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">private</span> <span class="class">Object</span> <span class="field">o</span>;	<span class="singleLineComment">// <span class="commentTaskTag">TODO</span> needs better name</span><br/>
 <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;<span class="javadoc">/**<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* Javadoc. Creates a new demo.<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* <span class="javadocKeyword">@param</span> o The object to demonstrate<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*/<br/></span>
 &nbsp;&nbsp;&nbsp;&nbsp;<span class="annotation">@DemoAnnotation</span><br />
-&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">public</span> Demo(<span class="typeParameter">Object</span> <span class="parameterVariable">o</span>) <span class="bracket">{</span><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">public</span> <span class="methodDeclaration">Demo</span>(<span class="class">Object</span> <span class="localVariable"><span class="parameterVariable">o</span></span>) <span class="bracket">{</span><br/>
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">this</span>.o = <span class="parameterVariable">o</span>; <span class="multiLineComment">/* multiline comment */</span><br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="class">String</span> s = <span class="staticFinalField">CONSTANT</span>;<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">int</span> <span class="localVariable">i</span> = <span class="number">12345678</span>;<br/>
-
-
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">this</span>.<span class="field">o</span> = <span class="localVariable"><span class="parameterVariable">o</span></span>; <span class="multiLineComment">/* multiline comment */</span><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="class">String</span> <span class="localVariableDeclaration">s</span> = <span class="staticFinalField">CONSTANT</span>;<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">int</span> <span class="localVariableDeclaration">i</span> = <span class="number">12345678</span>;<br/>
 </body>
-
 </html>

--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/preview.html
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/preview.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Theme previewer</title>
+<style type="text/css">
+${theme_css}
+</style>
+</head>
+<body class="defaultClass">
+<span class="keyword">public class</span> <span class="class">Demo</span> <span class="bracket">{</span><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">private static final</span> <span class="class">String</span> <span class="staticFinalField">CONSTANT</span> = <span class="string">"String"</span>;<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">private</span> <span class="class">Object</span> o;	<span class="singleLineComment">// TODO needs better name</span><br/> 
+<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="javadoc">/**<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* Creates a new demo.<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* <span class="javadocKeyword">@param</span> o The object to demonstrate<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*/<br/></span>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="annotation">@DemoAnnotation</span><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">public</span> Demo(<span class="typeParameter">Object</span> <span class="parameterVariable">o</span>) <span class="bracket">{</span><br/>
+	
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">this</span>.o = <span class="parameterVariable">o</span>; <span class="multiLineComment">/* multiline comment */</span><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="class">String</span> s = <span class="staticFinalField">CONSTANT</span>;<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">int</span> <span class="localVariable">i</span> = <span class="number">12345678</span>;<br/>
+
+
+</body>
+
+</html>

--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/preview.html
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/preferences/preview.html
@@ -12,15 +12,15 @@ ${theme_css}
 &nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">private</span> <span class="class">Object</span> o;	<span class="singleLineComment">// TODO needs better name</span><br/> 
 <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;<span class="javadoc">/**<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* Creates a new demo.<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* Javadoc. Creates a new demo.<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* <span class="javadocKeyword">@param</span> o The object to demonstrate<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*/<br/></span>
 &nbsp;&nbsp;&nbsp;&nbsp;<span class="annotation">@DemoAnnotation</span><br />
 &nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">public</span> Demo(<span class="typeParameter">Object</span> <span class="parameterVariable">o</span>) <span class="bracket">{</span><br/>
-	
-&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">this</span>.o = <span class="parameterVariable">o</span>; <span class="multiLineComment">/* multiline comment */</span><br/>
-&nbsp;&nbsp;&nbsp;&nbsp;<span class="class">String</span> s = <span class="staticFinalField">CONSTANT</span>;<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">int</span> <span class="localVariable">i</span> = <span class="number">12345678</span>;<br/>
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">this</span>.o = <span class="parameterVariable">o</span>; <span class="multiLineComment">/* multiline comment */</span><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="class">String</span> s = <span class="staticFinalField">CONSTANT</span>;<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="keyword">int</span> <span class="localVariable">i</span> = <span class="number">12345678</span>;<br/>
 
 
 </body>


### PR DESCRIPTION
Implements a theme previewer by using the browser widget.
Added a small html page "preview.html" which is used as a template for showing the theme.
Then creates a css from the theme object and inserts that into the html.
Fixes issue #70, make theme previews work offline.

Added the note in CHANGES.md on the 1.1.0 version.
