### PR TITLE
Reset preferences properly for CEditorMapping

### DIFF
--- a/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/mapper/CEditorMapper.java
+++ b/com.github.eclipsecolortheme/src/com/github/eclipsecolortheme/mapper/CEditorMapper.java
@@ -6,9 +6,17 @@ import com.github.eclipsecolortheme.ColorThemeMapping;
 import com.github.eclipsecolortheme.ColorThemeSetting;
 
 public class CEditorMapper extends GenericMapper {
+    private final String SOURCE_HOVER_BACKGROUND_COLOR_SYSTEM_DEFAULT_ID = "sourceHoverBackgroundColor.SystemDefault";
+
     @Override
     public void map(Map<String, ColorThemeSetting> theme, Map<String, ColorThemeMapping> overrideMappings) {
-        preferences.putBoolean("sourceHoverBackgroundColor.SystemDefault", false);
+        preferences.putBoolean(SOURCE_HOVER_BACKGROUND_COLOR_SYSTEM_DEFAULT_ID, false);
         super.map(theme, overrideMappings);
+    }
+
+    @Override
+    public void clear() {
+        preferences.remove(SOURCE_HOVER_BACKGROUND_COLOR_SYSTEM_DEFAULT_ID);
+        super.clear();
     }
 }


### PR DESCRIPTION
The sourceHoverBackgroundColor.systemDefault property was set but never cleared.
This causes the default theme to not reset properly, leaving inconsistency.

This fixes issue #129 .