### PR TITLE
Issue #63, updated color preference keys for the JSON Editor Plugin

### DIFF
--- a/com.github.eclipsecolortheme/mappings/jsonedit-core.xml
+++ b/com.github.eclipsecolortheme/mappings/jsonedit-core.xml
@@ -5,5 +5,14 @@
       <mapping pluginKey="defaultColor" themeKey="foreground" />
       <mapping pluginKey="valueColor" themeKey="field" />
       <mapping pluginKey="nullColor" themeKey="foreground" />
+
+      <!-- Newer versions of jsonedit uses these preferences instead -->
+      <mapping pluginKey="styleText.color" themeKey="string" />
+      <mapping pluginKey="styleDefault.color" themeKey="foreground" />
+      <mapping pluginKey="styleKey.color" themeKey="field" />
+      <mapping pluginKey="styleNull.color" themeKey="foreground" />
+      <mapping pluginKey="styleNumber.color" themeKey="number" />
+      <mapping pluginKey="styleBoolean.color" themeKey="keyword" />
+      <mapping pluginKey="styleError.color" themeKey="foreground" />
     </mappings>
 </eclipseColorThemeMapping>


### PR DESCRIPTION
This fixes issue #63 and was triggered by issue #252 
The preference values used for coloring has changed since support first  was added.