### PR TITLE
#262 - Inkpot theme: Java static fields and methods are unreadable

### DIFF
--- a/com.github.eclipsecolortheme/themes/inkpot.xml
+++ b/com.github.eclipsecolortheme/themes/inkpot.xml
@@ -14,6 +14,9 @@
     <string color="#FFCD8B" />
     <operator color="#CFBFAD" />
     <keyword color="#808BED" />
+    <staticMethod color="#CFBFAD" />
+    <staticField color="#CFBFAD" />
+    <staticFinalField color="#CFBFAD" />
     <background color="#1F1F27" />
     <currentLine color="#2D2D44" />
     <foreground color="#CFBFAD" />


### PR DESCRIPTION
Static fields and methods are unreadable when using Inkpot theme:
<img width="365" alt="before" src="https://cloud.githubusercontent.com/assets/644582/24428081/32af6086-13db-11e7-8373-84f66b2e5f70.png">
This PR set colors that are more prominent on dark background: 
<img width="353" alt="after" src="https://cloud.githubusercontent.com/assets/644582/24428080/32aa429a-13db-11e7-825c-2f32e9cf6829.png">

